### PR TITLE
Fix send later for hero and gold club raid

### DIFF
--- a/TravianTaskQueue/TravianTaskQueue.user.js
+++ b/TravianTaskQueue/TravianTaskQueue.user.js
@@ -1952,7 +1952,7 @@ function createAttackLinks() {
 		if( heroBox[0].firstElementChild == null ) {  //no hero textbox - make one
 			heroBox[0].innerHTML = " <img class='unit uhero' src='/img/x.gif' title='"
 				+aLangTroops[10]+"' onclick='document.snd.t11.value=\"\"; return false;' alt='"+aLangTroops[10]+"' style='cursor:pointer' />"
-				+" <input type='text' class='text' name='t11' value='' />"
+				+" <input type='text' class='text' name='troop[t11]' value='' />"
 				+" <a style='cursor:pointer'>(1)<br />(" +aLangStrings[33]+ ")</a>";
 		}
 		//Set the last line of table to top-aligned

--- a/TravianTaskQueue/TravianTaskQueue.user.js
+++ b/TravianTaskQueue/TravianTaskQueue.user.js
@@ -2368,7 +2368,7 @@ function sendGoldClub2(httpRequest,aTask) {
 			var holder = document.createElement('div');
 			holder.innerHTML = data.lists[0].html;
 			var tInputs = holder.getElementsByTagName('input');
-			var checksum = xpath("//script[contains(text(),'Travian.Game.RaidList.checksum')]", holderFarm, true);
+			var checksum = xpath("//script[contains(text(),'Travian.Game.RaidList.checksum')]", holderFarm, true, holderFarm);
 			if (tInputs.length > 4 ) {
 				var sParams = {};
 				sParams["action"] = "raidList";


### PR DESCRIPTION
Script Name
Travian Task Queue

Server address
ts6.x1.asia.travian.com

User script manager
Tampermonkey

Operating System
Windows 10

Describe the bug
- Choosing the hero for send later resulted in sending Equites Caesaris (as a Roman) instead
- Queued gold club raid not activated due to `Node cannot be used in a document other than the one in which it was created.`

Changes
- The troops value seem to be using `troop[t##]` format now, adding the format works locally on Chrome and Firefox
- document.evaluate(xpath, node, null, XPathResultType, null) mentions the exception as document is not the same node as holderFarm. Added holderFarm into the parameter of xpath function works flawlessly on Chrome and Firefox