### PR TITLE
Total Oasis Supply Point in Neighbors List

### DIFF
--- a/TravianResourceBarPlus/TravianResourceBarPlus.user.js
+++ b/TravianResourceBarPlus/TravianResourceBarPlus.user.js
@@ -12,14 +12,14 @@
 // @exclude     *.css
 // @exclude     *.js
 
-// @version        2.24.9
+// @version        2.25.0
 // ==/UserScript==
 
 (function () {
 var RunTime = [Date.now()];
 
 function allInOneOpera () {
-var version = '2.24.9';
+var version = '2.25.0';
 
 notRunYet = false;
 
@@ -7328,6 +7328,9 @@ function cropFind () {
 								newT.rows[i].cells[2].appendChild($em('SPAN',[tc+"x",trImg('unit u'+tt)]));
 						}
 					}
+                    if (chkOasisFL[vid] && newT.rows[i].cells[2]) {
+                        newT.rows[i].cells[2].appendChild($em('SPAN',[chkOasisFL[vid].rows[0].cells[4].innerText],[['style','color: magenta; font-weight: bold;']]));
+                    }
 				}
 			} else {
 				var oasisCC = 0;


### PR DESCRIPTION
I use neighbors list below map when i want to increase my hero's xp. However, i always need to hover over to see the total oasis supply point in each oasis in the list. 

Improving this feature would solve the mentioned issue.

This is how it will look like:
![image](https://github.com/adipiciu/Travian-scripts/assets/24757798/80a07638-b843-4301-aa70-8180b8eeab3f)
