### PR TITLE
Added Trade (T) (T+) system for NPC Exchange Resources

### DIFF
--- a/TravianResourceBarPlus/TravianResourceBarPlus.user.js
+++ b/TravianResourceBarPlus/TravianResourceBarPlus.user.js
@@ -100,6 +100,7 @@ var RB = new Object();
 	RB.village_PPH = [0,0,0,0,0,0,0,0,0,0,0,0,0];
 	RB.overview = [-1,'0'];
 	RB.wantsMem = [0,0,0,0,0,0,0,0,0,0];
+	RB.wantsTrade = [0,0,0,0];
 //						1		2				3				4			5					6				7			8		9			10		11		12	  13, 14	15		16				17				18				19				20					21			22		23		24				25				26			27		28			29			30		31			32
 	RB.dictionary = [0,'Ally','Merchants','Tournament Square','Duration','resource balance','Rally Point','Marketplace','Barracks','Stable','Workshop','Buy','Attacks',0,'at ','Map','Reinforcement','Attack: Normal','Attack: Raid','Culture points','Crop consumption','capacity','Farm List','','Great Barracks','Great Stable','Hospital','Asclepeion','Harbor','Town Hall','Smithy','Overview','Send Troops'];
 	RB.dictFL = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
@@ -3250,6 +3251,11 @@ function needed_show( base ) {
 		saveCookie('Mem', 'wantsMem');
 		alert( noplace +"\nSaved: "+ RB.wantsMem[0] +" | "+ RB.wantsMem[1] +" | "+ RB.wantsMem[2] +" | "+ RB.wantsMem[3] );
 	}
+	function saveWantsTrade ( tradeResM ) {
+		RB.wantsTrade = tradeResM.slice();
+		saveCookie('Trade', 'wantsTrade');
+		alert( "Trade saved: "+ RB.wantsTrade[0] +" | "+ RB.wantsTrade[1] +" | "+ RB.wantsTrade[2] +" | "+ RB.wantsTrade[3] );
+	}
 	function showPlusTimer () {
 		if (RB.Setup[10] > 2 && $g('merchantsOnTheWay')) return;
 		var j=timerB.length;
@@ -3300,6 +3306,17 @@ function needed_show( base ) {
 		var memP = $a(' (M+)',[['href',jsVoid]]);
 		memP.addEventListener('click', function(x) { return function() { saveWantsMem(x); }}(wantsResMemP), 0);
 		beforeThis.appendChild(memP);
+	}
+
+	var tradeResMem = [wantsResMem[5],wantsResMem[6],wantsResMem[7],wantsResMem[8]];
+	var tradeResMemP = [parseInt(RB.wantsTrade[0])+tradeResMem[0],parseInt(RB.wantsTrade[1])+tradeResMem[1],parseInt(RB.wantsTrade[2])+tradeResMem[2],parseInt(RB.wantsTrade[3])+tradeResMem[3]];
+	var memT = $a(' (T)',[['href',jsVoid]]);
+	memT.addEventListener('click', function(x) { return function() { saveWantsTrade(x); }}(tradeResMem), 0);
+	beforeThis.appendChild(memT);
+	if( parseInt(RB.wantsTrade[0])+parseInt(RB.wantsTrade[1])+parseInt(RB.wantsTrade[2])+parseInt(RB.wantsTrade[3]) > 0 ) {
+		var memTP = $a(' (T+)',[['href',jsVoid]]);
+		memTP.addEventListener('click', function(x) { return function() { saveWantsTrade(x); }}(tradeResMemP), 0);
+		beforeThis.appendChild(memTP);
 	}
 
 	return beforeThis;
@@ -4479,6 +4496,7 @@ function loadAllCookie () {
 	loadVCookie ( 'VV', 'village_Var' );
 	loadCookie ( 'OV', 'overview' );
 	loadCookie ( 'Mem', 'wantsMem' );
+	loadCookie ( 'Trade', 'wantsTrade' );
 	loadCookie ( 'DictTR', 'dictTR' );
 	loadCookie ( 'AS', 'serversAN' );
 
@@ -7905,6 +7923,21 @@ function npcForTroops () {
 	var newA = $a(($e('i',[['class','r4']])),[['href',jsVoid],['onclick','setTimeout(function (x) { return exchangeResources.calculateRest() },250)']]);
 	newA.addEventListener('click',redistrNPCcrop, false);
 	TR.appendChild($c(newA));
+	if( parseInt(RB.wantsTrade[0])+parseInt(RB.wantsTrade[1])+parseInt(RB.wantsTrade[2])+parseInt(RB.wantsTrade[3]) > 0 ) {
+		var tradeA = $a('T',[['href',jsVoid],['style','font-weight:700;margin-left:5px;'],['onclick','setTimeout(function (x) { return exchangeResources.calculateRest() },250)']]);
+		tradeA.addEventListener('click', function() {
+			for( var i=0; i<4; i++ ) inps[i].value = parseInt(RB.wantsTrade[i]);
+			tT.parentNode.removeChild(tT);
+			npcForTroops();
+		}, false);
+		TR.appendChild($c(tradeA));
+	}
+	var refreshA = $a('R',[['href',jsVoid],['style','font-weight:700;margin-left:5px;'],['onclick','setTimeout(function (x) { return exchangeResources.calculateRest() },250)']]);
+	refreshA.addEventListener('click', function() {
+		tT.parentNode.removeChild(tT);
+		npcForTroops();
+	}, false);
+	TR.appendChild($c(refreshA));
 	var tT = $ee('TABLE',TR,[['class',allIDs[7]]]);
 	npcT.parentNode.insertBefore(tT, npcT);
 }


### PR DESCRIPTION
## Summary

Added a new Trade memory system (T/T+) that works alongside the existing Market memory (M/M+), but stores the full resource cost of buildings instead of only what's missing.

- (T) button on building pages saves the total resource cost (all 4 resources)
- (T+) button accumulates costs from multiple buildings
- On the NPC Exchange Resources page, a "T" button fills the inputs with the stored trade values and recalculates the troop distributor
- "R" button on the NPC Exchange page allows manual refresh of the troop distributor after editing input values by hand

## How it works

1. Navigate to any building upgrade page
2. Click (T) to save the full cost, or (T+) to add to a previous value
3. Open the NPC Exchange Resources modal
4. Click "T" to fill the exchange inputs with the accumulated values — troop distributor updates automatically
5. Optionally edit values manually, then click "R" to refresh the troop distributor

Unlike the Market memory (M), which only stores what's missing (current resources minus cost), the Trade memory stores the complete cost regardless of current resources.

## Usage Examples:

### Usage 1:
- Navigate through your secondary villages and keep adding the trades you want to perform (T+).
- Go to your main 15-crop village.
- Make a single large trade that distributes the exact resources.
- Use the remaining resources for troop training.
- Send the resources to the secondary villages.

### Usage 2:
- Add up several building upgrades you want to trade in a single village.
- Make one trade and use the rest for troops.
- Schedule the building upgrades (use the master builder if necessary).